### PR TITLE
Implement a new class for exceptions due to convergence errors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,12 @@ from subdirs import *
 # stopped automatically
 espresso_calculators = []
 
+# Define types of convergence errors that can be used to handle convergence error automatically
+class ConvergenceError(Exception):
+    pass
+    
+class KohnShamConvergenceError(ConvergenceError):
+    pass
 
 class espresso(Calculator):
     """
@@ -1155,7 +1161,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
                     break
             if a[:20]=='     convergence NOT':
                 self.stop()
-                raise RuntimeError, 'scf cycles did not converge\nincrease maximum number of steps and/or decreasing mixing'
+                raise KohnShamConvergenceError('scf cycles did not converge\nincrease maximum number of steps and/or decreasing mixing')
             elif a[:13]=='     stopping':
                 self.stop()
                 self.checkerror()

--- a/multiespresso.py
+++ b/multiespresso.py
@@ -7,7 +7,7 @@
 #****************************************************************************
 
 
-from espresso import espresso
+from espresso import espresso, KohnShamConvergenceError
 from sys import stderr
 
 #keep track of ourselves so we can automatically stop us
@@ -68,7 +68,7 @@ class multiespresso:
                         if a[:13]=='     stopping':
                             raise RuntimeError, 'problem with calculator #%d' % i
                         elif a[:20]=='     convergence NOT':
-                            raise RuntimeError, 'calculator #%d did not converge' % i
+                            raise KohnShamConvergenceError('calculator #%d did not converge' % i)
                         elif a[1:17]!='    total energy':
                             stderr.write(a)
                         else:


### PR DESCRIPTION
I have implemented a very small class for SCF convergence errors. With this class, it becomes possible to automatically alter parameters in a calculation if an SCF convergence error occurs. For example, one can try to converge with a mixing beta parameter of 0.7, catch a KohnShamConvergenceError with a try: except: clause, reduce beta to 0.35 (or do another change), and try again. In this way, one can go to increasingly more demanding mixing parameters as the need arises, rather than always using it and spending more time finishing calculations. This type of error handling is used in GPAW, and it is basically the same code as is used there: https://gitlab.com/gpaw/gpaw/blob/master/gpaw/__init__.py
