### PR TITLE
compatibility with newer numpy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1005,7 +1005,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
                 self.nbnd = int(self.nbands)
             else:
             #if self.nbands is negative create -self.nbands extra bands
-                if self.nvalence == None:
+                if self.nvalence is None:
                      self.nvalence, self.nel =  self.get_nvalence()
                 if self.noncollinear:
                     self.nbnd = int(np.sum(self.nvalence)-self.nbands*2.)


### PR DESCRIPTION
If y is an array,  `x == y` returns an array of booleans in newer numpy versions, whereas `x is y` always returns a boolean.