### PR TITLE
unicode / binary file reading patches

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -450,8 +450,8 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         self.xc = xc
         self.beefensemble = beefensemble
         self.printensemble = printensemble
-        if type(smearing)==str:
-            self.smearing = smearing
+        if isinstance(smearing, (str, unicode)):
+            self.smearing = str(smearing)
             self.sigma = sigma
         else:
             self.smearing = smearing[0]
@@ -1436,7 +1436,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
             kp = self.kpts
         else:
             kp = overridekpts
-        if kp == 'gamma':
+        if kp is 'gamma':
             print >>f, 'K_POINTS Gamma'
         else:
             x = np.shape(kp)
@@ -2167,7 +2167,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         return self.ST
 
     def checkerror(self):
-        p = os.popen('grep -n Giannozzi '+self.log+' | tail -1','r')
+        p = os.popen('grep -n --text Giannozzi '+self.log+' | tail -1','r')
         try:
             n = int(p.readline().split()[0].strip(':'))
         except:

--- a/__init__.py
+++ b/__init__.py
@@ -1713,7 +1713,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
             if self.calcmode in ('relax','vc-relax','vc-md','md'):
                 if self.opt_algorithm == 'ase3':
                     self.stop()
-                p = os.popen('grep -n "!    total" '+self.log+' | tail -1','r')
+                p = os.popen('grep -a -n "!    total" '+self.log+' | tail -1','r')
                 n = int(p.readline().split(':')[0])-1
                 p.close()
                 f = open(self.log,'r')
@@ -2010,7 +2010,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
 
         self.stop()
 
-        p = os.popen('grep -n Giannozzi '+self.log+'| tail -1','r')
+        p = os.popen('grep -a -n Giannozzi '+self.log+'| tail -1','r')
         n = int(p.readline().split()[0].strip(':'))
         p.close()
 
@@ -2088,7 +2088,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
     def get_nonselfconsistent_energies(self, type='beefvdw'):
         #assert self.xc is 'BEEF'
         self.stop()
-        p = os.popen('grep -32 "BEEF-vdW xc energy contributions" '+self.log+' | tail -32','r')
+        p = os.popen('grep -a -32 "BEEF-vdW xc energy contributions" '+self.log+' | tail -32','r')
         s = p.readlines()
         p.close()
         xc = np.array([])
@@ -2110,7 +2110,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
 
         self.stop()
 
-        p = os.popen('grep -3 "total   stress" '+self.log+' | tail -3','r')
+        p = os.popen('grep -a -3 "total   stress" '+self.log+' | tail -3','r')
         s = p.readlines()
         p.close()
 
@@ -2144,10 +2144,10 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         Units are Bohr magnetons per unit cell, directly read PWscf log.
         Returns (0,0) if no magnetization is found in log.
         """
-        p1 = os.popen('grep "total magnetization" '+self.log+' | tail -1','r')
+        p1 = os.popen('grep -a "total magnetization" '+self.log+' | tail -1','r')
         s1 = p1.readlines()
         p1.close()
-        p2 = os.popen('grep "absolute magnetization" '+self.log+' | tail -1','r')
+        p2 = os.popen('grep -a "absolute magnetization" '+self.log+' | tail -1','r')
         s2 = p2.readlines()
         p2.close()
 
@@ -2167,14 +2167,14 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         return self.ST
 
     def checkerror(self):
-        p = os.popen('grep -n --text Giannozzi '+self.log+' | tail -1','r')
+        p = os.popen('grep -a -n Giannozzi '+self.log+' | tail -1','r')
         try:
             n = int(p.readline().split()[0].strip(':'))
         except:
             raise RuntimeError, 'Espresso executable doesn\'t seem to have been started.'
         p.close()
 
-        p = os.popen(('tail -n +%d ' % n)+self.log+' | grep -n %%%%%%%%%%%%%%%% |tail -2','r')
+        p = os.popen(('tail -n +%d ' % n)+self.log+' | grep -a -n %%%%%%%%%%%%%%%% |tail -2','r')
         s = p.readlines()
         p.close()
 
@@ -2354,7 +2354,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
             return self.inputfermilevel
         self.stop()
         try:
-            p = os.popen('grep Fermi '+self.log+'|tail -1', 'r')
+            p = os.popen('grep -a Fermi '+self.log+'|tail -1', 'r')
             efermi = float(p.readline().split()[-2])
             p.close()
         except:
@@ -2423,7 +2423,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
                 suppressforcecalc=True)
             self.run_espressox(self.exedir+'pw.x', 'pwnscf.inp', 'pwnscf.log')
             if nscf_fermilevel:
-                p = os.popen('grep Fermi '+self.localtmp+'/pwnscf.log|tail -1', 'r')
+                p = os.popen('grep -a Fermi '+self.localtmp+'/pwnscf.log|tail -1', 'r')
                 efermi = float(p.readline().split()[-2])
                 p.close()
 
@@ -2556,7 +2556,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
 
     def __get_atomic_projections__(self):
         f = open(self.scratch+'/calc.save/atomic_proj.xml', 'r')
-        p = os.popen('grep -n Giannozzi '+self.localtmp+'/pdos.log|tail -1','r')
+        p = os.popen('grep -a -n Giannozzi '+self.localtmp+'/pdos.log|tail -1','r')
         n = p.readline().split()[0].strip(':').strip()
         p.close()
         p = os.popen('tail -n +'+n+' '+self.localtmp+'/pdos.log|grep "state #"', 'r')
@@ -2634,17 +2634,17 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         self.stop()
 
         if self.spinpol:
-            p = os.popen("grep eigenval1.xml "+self.scratch+"/calc.save/data-file.xml|tr '\"' ' '|awk '{print $(NF-1)}'", 'r')
+            p = os.popen("grep -a eigenval1.xml "+self.scratch+"/calc.save/data-file.xml|tr '\"' ' '|awk '{print $(NF-1)}'", 'r')
             kptdirs1 = [x.strip() for x in p.readlines()]
             p.close()
             kptdirs1.sort()
-            p = os.popen("grep eigenval2.xml "+self.scratch+"/calc.save/data-file.xml|tr '\"' ' '|awk '{print $(NF-1)}'", 'r')
+            p = os.popen("grep -a eigenval2.xml "+self.scratch+"/calc.save/data-file.xml|tr '\"' ' '|awk '{print $(NF-1)}'", 'r')
             kptdirs2 = [x.strip() for x in p.readlines()]
             p.close()
             kptdirs2.sort()
             kptdirs = kptdirs1+kptdirs2
         else:
-            p = os.popen("grep eigenval.xml "+self.scratch+"/calc.save/data-file.xml|tr '\"' ' '|awk '{print $(NF-1)}'", 'r')
+            p = os.popen("grep -a eigenval.xml "+self.scratch+"/calc.save/data-file.xml|tr '\"' ' '|awk '{print $(NF-1)}'", 'r')
             kptdirs = [x.strip() for x in p.readlines()]
             p.close()
             kptdirs.sort()
@@ -2966,7 +2966,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         else:
             raise ValueError, 'unknown spin component'
         if self.spinpol:
-            p = os.popen('grep "number of k points=" '+self.log+'|tail -1|tr \'=\' \' \'', 'r')
+            p = os.popen('grep -a "number of k points=" '+self.log+'|tail -1|tr \'=\' \' \'', 'r')
             nkp = int(p.readline().split()[4])
             p.close()
             kp = kpoint+nkp/2*s
@@ -3005,7 +3005,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         else:
             raise ValueError, 'unknown spin component'
         if self.spinpol:
-            p = os.popen('grep "number of k points=" '+self.log+'|tail -1|tr \'=\' \' \'', 'r')
+            p = os.popen('grep -a "number of k points=" '+self.log+'|tail -1|tr \'=\' \' \'', 'r')
             nkp = int(p.readline().split()[4])
             p.close()
             kp = kpoint+nkp/2*s
@@ -3387,7 +3387,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         vacuum_energy = average_data[np.abs(np.array(average_data)[..., 0] - vacuum_pos).argmin()][1]
 
         # Get the latest Fermi energy
-        fermi_data = os.popen('grep -n "Fermi" ' + self.log + ' | tail -1', 'r')
+        fermi_data = os.popen('grep -a -n "Fermi" ' + self.log + ' | tail -1', 'r')
         fermi_energy = float(fermi_data.readline().split()[-2])
         fermi_data.close()
 
@@ -3453,7 +3453,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
             tail = 'tail'
         else:
             tail = 'tail -1'
-        p = os.popen('grep "convergence has been achieved in" '+self.log+' | '+tail, 'r')
+        p = os.popen('grep -a "convergence has been achieved in" '+self.log+' | '+tail, 'r')
         s = p.readlines()
         p.close()
         if not all:
@@ -3470,7 +3470,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
 
     def get_number_of_bfgs_steps(self):
         """Get total number of internal BFGS steps."""
-        p = os.popen('grep "bfgs converged in" '+self.log+' | tail -1', 'r')
+        p = os.popen('grep -a "bfgs converged in" '+self.log+' | tail -1', 'r')
         s = p.readlines()
         p.close()
         assert len(s) < 2


### PR DESCRIPTION
1. Handle unicode reading error for smearing (python 3).
2.  Change '==' to 'is' to prevent ambiguity warnings.
3.  Add '--text' to grep command in `checkerror` to properly handle reading binary format.