### PR TITLE
Solve minor bug involving QE output filename

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -661,10 +661,10 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
         # Run initialization functions, such that this can be called if variables in espresso are
         #changes using set or directly.
 
-        self.create_outdir() # Create the tmp output folder
-
         #sdir is the directory the script is run or submitted from
         self.sdir = getsubmitorcurrentdir(site)
+	
+	self.create_outdir() # Create the tmp output folder
 
         if self.dw is None:
             self.dw = 10. * self.pw
@@ -703,7 +703,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
             if not self.txt:
                 self.log = self.localtmp+'/log'
             elif self.txt[0]!='/':
-                self.log = self.sdir+'/log'
+                self.log = self.sdir+'/'+self.txt
             else:
                 self.log = self.txt
             self.scratch = mkscratch(self.localtmp, site)


### PR DESCRIPTION
Changes at lines 664-667 solve a bug where ase-espresso would fail if a filename without a leading slash is provided in the "txt" argument to the initializer (initialize self.sdir before using it). Change in line 706 makes ase-espresso actually use the filename provided by the user, otherwise it gets ignored.